### PR TITLE
Remove "--allow-http" Argument

### DIFF
--- a/jupyter_codeserver_proxy/__init__.py
+++ b/jupyter_codeserver_proxy/__init__.py
@@ -17,7 +17,7 @@ def setup_codeserver():
         if working_dir is None:
             working_dir = os.getenv("JUPYTER_SERVER_ROOT", ".")
 
-        return [full_path, '--port=' + str(port), "--allow-http", "--auth", "none", working_dir ]
+        return [full_path, '--port=' + str(port), "--auth", "none", working_dir ]
 
     return {
         'command': _codeserver_command,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="jupyter-codeserver-proxy",
-    version='1.0b3',
+    version='1.0b4',
     url="https://github.com/dirkcgrunwald/jupyter-codeserver-proxy.git",
     author="Dirk Grunwald based on Project Jupyter Contributors",
     description="grunwald@colorado.edu",


### PR DESCRIPTION
The current version of code-server no longer has the argument "--allow-http". In effect, running
```
code-server
```
will result in the server not starting and saying
```
***** Please use the script in bin/code-server instead!
***** This script will soon be removed!
***** See the release notes at https://github.com/cdr/code-server/releases/tag/v3.4.0
Unknown option --allow-http
```

This pull request removes the argument "--allow-http", so that the code-server will still run.